### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Please site our paper if you find this repository useful.
 
 ## Documentation
 
-Check [the documentation](https://jerry871002.github.io/bayesian-strategy-inference/) to see how to run the experiments.
+Check [the documentation](https://jerry871002.github.io/bsi-pt/) to see how to run the experiments.


### PR DESCRIPTION
The repo was renamed to `bsi-pt`, so the URL of the document site was also changed.